### PR TITLE
Support multilang tags in different places.

### DIFF
--- a/classes/external.php
+++ b/classes/external.php
@@ -381,7 +381,7 @@ class external extends external_api {
         $labels = get_config('tool_supporter', 'level_labels');
         $count = 1; // Root is level 0, so we begin at 1.
         foreach (explode(';', $labels) as $label) {
-            $data['label_level_'.$count] = $label; // Each label will be available under {{label_level_0}}, {{label_level_1}}, etc.
+            $data['label_level_'.$count] = external_format_string($label, $context); // Each label will be available under {{label_level_0}}, {{label_level_1}}, etc.
             $count++;
         }
 
@@ -541,19 +541,24 @@ class external extends external_api {
                 $category = $categories[$course->category];
                 $patharray = explode("/", $category->path);
                 if (isset($patharray[1])) {
-                    $patharray[1] = $categories[$patharray[1]]->name;
+                    // Support multilang course categories.
+                    $patharray[1] = external_format_string($categories[$patharray[1]]->name, $context);
                     $course->level_one = $patharray[1];
                 } else {
                     $course->level_one = "";
                 }
                 if (isset($patharray[2])) {
-                    $patharray[2] = $categories[$patharray[2]]->name;
+                    // Support multilang course categories.
+                    $patharray[2] = external_format_string($categories[$patharray[2]]->name, $context);
                     $course->level_two = $patharray[2];
                 } else {
                     $course->level_two = "";
                 }
-                $coursesarray[] = (array)$course;
 
+                // Support multilang course fullnames.
+                $course->fullname = external_format_string($course->fullname, $context);
+
+                $coursesarray[] = (array)$course;
             }
         }
         $data['courses'] = $coursesarray;
@@ -562,10 +567,12 @@ class external extends external_api {
         $data['uniqueleveltwoes'] = [];
         foreach ($categories as $category) {
             if ($category->depth == 1) {
-                array_push($data['uniquelevelones'], $category->name);
+                // Support multilang course categories.
+                array_push($data['uniquelevelones'], external_format_string($category->name, $context));
             }
             if ($category->depth == 2) {
-                array_push($data['uniqueleveltwoes'], $category->name);
+                // Support multilang course categories.
+                array_push($data['uniqueleveltwoes'], external_format_string($category->name, $context));
             }
         }
 
@@ -577,7 +584,7 @@ class external extends external_api {
         $labels = get_config('tool_supporter', 'level_labels');
         $count = 1; // Root is level 0, so we begin at 1.
         foreach (explode(';', $labels) as $label) {
-            $data['label_level_'.$count] = $label; // Each label will be available under {{label_level_0}}, {{label_level_1}}, etc.
+            $data['label_level_'.$count] = external_format_string($label, $context); // Each label will be available under {{label_level_0}}, {{label_level_1}}, etc.
             $count++;
         }
 
@@ -663,6 +670,8 @@ class external extends external_api {
         $coursedetails = $DB->get_record_sql($select);
         $coursedetails = (array)$coursedetails;
         $coursedetails['timecreated'] = date('Y-m-d H:i:s', $coursedetails['timecreated']); // Convert timestamp to readable format.
+        // Support course multilang fullnames.
+        $coursedetails['fullname'] = external_format_string($coursedetails['fullname'], $coursecontext);
 
         // Get whole course-path.
         // Extract IDs from path and remove empty values by using array_filter.
@@ -672,7 +681,8 @@ class external extends external_api {
         $parentcatnames = $DB->get_records_list('course_categories', 'id', $parentcategoriesids, null, 'id,name');
         $pathcategories = [];
         foreach ($parentcatnames as $val) {
-            $pathcategories[] = $val->name;
+            // Support multilang course categories.
+            $pathcategories[] = external_format_string($val->name, $coursecontext);
         }
         $coursedetails['level_one'] = $pathcategories[0];
         isset($pathcategories[1]) ? $coursedetails['level_two'] = $pathcategories[1] : $coursedetails['level_two'] = "";
@@ -689,7 +699,8 @@ class external extends external_api {
         $rolesincourse = [];
 
         foreach ($usedrolesincourse as $rid => $rname) {
-            $rolename = $rname;
+            // Support multilang roles.
+            $rolename = external_format_string($rname, $coursecontext);
             $rolenumber = \count_role_users($rid, $coursecontext);
             if ($rolenumber != 0) {
                 $roles[] = ['roleName' => $rolename, 'roleNumber' => $rolenumber];
@@ -726,7 +737,10 @@ class external extends external_api {
         $modules = \get_array_of_activities($courseid);
         foreach ($modules as $mo) {
             $section = \get_section_name($courseid, $mo->section);
-            $activity = ['section' => $section, 'activity' => $mo->mod, 'name' => $mo->name, 'visible' => $mo->visible];
+            // Support section and activity multilang names.
+            $activity = ['section' => external_format_string($section, $coursecontext),
+                'activity' => get_string('pluginname', $mo->mod),
+                'name' => external_format_string($mo->name, $coursecontext), 'visible' => $mo->visible];
             $activities[] = $activity;
         }
 

--- a/classes/output/course_table.php
+++ b/classes/output/course_table.php
@@ -52,7 +52,7 @@ class course_table implements renderable, templatable {
         $labels = get_config('tool_supporter', 'level_labels');
         $count = 1; // Root is level 0, so we begin at 1.
         foreach (explode(';', $labels) as $label) {
-            $data['label_level_'.$count] = $label; // Each label will be available with {{label_level_0}}, {{label_level_1}}, etc.
+            $data['label_level_'.$count] = format_string($label); // Each label will be available with {{label_level_0}}, {{label_level_1}}, etc.
             $count++;
         }
 


### PR DESCRIPTION
This is great stuff, guys.

As working in a multilangual institution, we do user multilang all over the place.
Here's some fixes which cope with multilang role names, course names, section names, module names

<img width="579" alt="multilangsupport" src="https://user-images.githubusercontent.com/377279/61170683-345c6700-a56d-11e9-9549-1b006595f397.png">

<img width="541" alt="multilangsupport_2" src="https://user-images.githubusercontent.com/377279/61182078-a34dc480-a62e-11e9-86e4-94e7d3ef3128.png">
It could be I've left some off. Sorry!

FYI https://docs.moodle.org/dev/AJAX says to do so:

> Tricky things to know about using webservices with ajax calls: 
> (…)
> 2. Text returned from a webservice must be properly filtered. This means it must go through external_format_text or external_format_string (since 3.0 - see MDL-51213) with the correct context.

Best,
Luca