### PR TITLE
Update user_table.mustache

### DIFF
--- a/templates/user_table.mustache
+++ b/templates/user_table.mustache
@@ -112,11 +112,11 @@ function(loadInformation, $, ajax, notification, templates, datatables, tableFil
 
     var columns = [
                      {data: 'id', name: 'ID'},
-                     {data: 'idnumber', name: '{{#str}}idnumbermod{{/str}}'},
-                     {data: 'username', name: '{{#str}}username{{/str}}'},
-                     {data: 'firstname', name: '{{#str}}firstname{{/str}}'},
-                     {data: 'lastname', name: '{{#str}}lastname{{/str}}'},
-                     {data: 'email', name: '{{#str}}email{{/str}}'}
+                     {data: 'idnumber', name: "{{#str}}idnumbermod{{/str}}"},
+                     {data: 'username', name: "{{#str}}username{{/str}}"},
+                     {data: 'firstname', name: "{{#str}}firstname{{/str}}"},
+                     {data: 'lastname', name: "{{#str}}lastname{{/str}}"},
+                     {data: 'email', name: "{{#str}}email{{/str}}"}
                   ];
     datatables.dataTableAjax('#userTable', 'tool_supporter_get_users', {}, 'users', columns);
 


### PR DESCRIPTION
Double quoting enclosed mustache's moodle str calls.
(Moodle supporter was unusable in french yielding a "SyntaxError: missing } after property list" Browser error).

As some languages (like FR) use ' in article/promoun shortnening. expl "Nom d'utilisateur" for "username". Though the correct FR apostrophe should be "´" "Numéro d´identification" that change in moodle core lang would probably be harder one to negociate.

I think this little change should not break anything as one can assume field header Moodle Strings should not contain double quotes.
