### PR TITLE
Update user_table.mustache

### DIFF
--- a/templates/user_table.mustache
+++ b/templates/user_table.mustache
@@ -112,11 +112,11 @@ function(loadInformation, $, ajax, notification, templates, datatables, tableFil
 
     var columns = [
                      {data: 'id', name: 'ID'},
-                    {data: 'idnumber', name: '{{#htmlescape}}{{#str}}idnumbermod{{/str}}{{/htmlescape}}'},
-                     {data: 'username', name: '{{#htmlescape}}{{#str}}username{{/str}}{{/htmlescape}}'},
-                     {data: 'firstname', name: '{{#htmlescape}}{{#str}}firstname{{/str}}{{/htmlescape}}'},
-                     {data: 'lastname', name: '{{#htmlescape}}{{#str}}lastname{{/str}}{{/htmlescape}}'},
-                     {data: 'email', name: '{{#htmlescape}}{{#str}}email{{/str}}{{/htmlescape}}'}
+                    {data: 'idnumber', name: '{{#cleanstr}}idnumbermod{{/cleanstr}}'},
+                     {data: 'username', name: '{{#cleanstr}}username{{/cleanstr}}'},
+                     {data: 'firstname', name: '{{#cleanstr}}firstname{{/cleanstr}}'},
+                     {data: 'lastname', name: '{{#cleanstr}}lastname{{/cleanstr}}'},
+                     {data: 'email', name: '{{#cleanstr}}email{{/cleanstr}}'}
                   ];
     datatables.dataTableAjax('#userTable', 'tool_supporter_get_users', {}, 'users', columns);
 

--- a/templates/user_table.mustache
+++ b/templates/user_table.mustache
@@ -112,11 +112,11 @@ function(loadInformation, $, ajax, notification, templates, datatables, tableFil
 
     var columns = [
                      {data: 'id', name: 'ID'},
-                     {data: 'idnumber', name: '{{#str}}idnumbermod{{/str}}'},
-                     {data: 'username', name: '{{#str}}username{{/str}}'},
-                     {data: 'firstname', name: '{{#str}}firstname{{/str}}'},
-                     {data: 'lastname', name: '{{#str}}lastname{{/str}}'},
-                     {data: 'email', name: '{{#str}}email{{/str}}'}
+                    {data: 'idnumber', name: '{{#htmlescape}}{{#str}}idnumbermod{{/str}}{{/htmlescape}}'},
+                     {data: 'username', name: '{{#htmlescape}}{{#str}}username{{/str}}{{/htmlescape}}'},
+                     {data: 'firstname', name: '{{#htmlescape}}{{#str}}firstname{{/str}}{{/htmlescape}}'},
+                     {data: 'lastname', name: '{{#htmlescape}}{{#str}}lastname{{/str}}{{/htmlescape}}'},
+                     {data: 'email', name: '{{#htmlescape}}{{#str}}email{{/str}}{{/htmlescape}}'}
                   ];
     datatables.dataTableAjax('#userTable', 'tool_supporter_get_users', {}, 'users', columns);
 


### PR DESCRIPTION
Fixes the broken json with languages (like French) that could use single or doulle quotes in field headers.

Should be compatible with previous version to 4.0.
Since 4.0 one could replace {{#htmlescape}}{{#str}} with {{#cleanstr}} 