### PR TITLE
Remove table borders in Moodle ≥ 5.0

### DIFF
--- a/templates/course_detail.mustache
+++ b/templates/course_detail.mustache
@@ -210,7 +210,7 @@ Example context (json):
 		            </div>
 
 	                <div class="table table-responsive">
-	                    <table class="stripe hover row-border" id="userincourse">
+	                    <table class="stripe hover row-border table-reboot" id="userincourse">
 	                        <thead>
 	                            <tr>
                                     <th hidden="">ID</th>

--- a/templates/course_table.mustache
+++ b/templates/course_table.mustache
@@ -198,7 +198,7 @@ Example context (json):
     </div>
 
 	<div class = "table table-responsive">
-	  <table id = "courseTable" class="stripe hover row-border">
+	  <table id = "courseTable" class="stripe hover row-border table-reboot">
 	    <thead>
 	      <tr>
               <th>ID</th>

--- a/templates/user_detail.mustache
+++ b/templates/user_detail.mustache
@@ -224,7 +224,7 @@ Example context (json):
 
 	        <!--Table showing users courses-->
             <div class="table table-responsive">
-                <table class = "table stripe hover row-border" id="userdetailcourses">
+                <table class = "stripe hover row-border table-reboot" id="userdetailcourses">
 	              <thead>
 	                <tr>
 	                  <th>ID</th>

--- a/templates/user_table.mustache
+++ b/templates/user_table.mustache
@@ -87,7 +87,7 @@ Example context (json):
 	  </div>
 
 	 <div class = "table table-responsive">
-	     <table class = "stripe hover row-border" id = "userTable">
+	     <table class = "stripe hover row-border table-reboot" id = "userTable">
 	         <thead>
 				<tr>
 			        <th>ID</th>


### PR DESCRIPTION
Note this uses Moodle 5.0.3.
The necessary .table-reboot table class comes with that version.